### PR TITLE
Add .tlog to the Visual Studio template

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -90,6 +90,7 @@ StyleCopReport.xml
 *.tmp_proj
 *_wpftmp.csproj
 *.log
+*.tlog
 *.vspscc
 *.vssscc
 .builds


### PR DESCRIPTION
**Reasons for making this change:**

.tlog files should not be committed to source control.

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/questions/41417471/what-are-these-tlog-files-should-these-be-part-of-my-source-control
"[These] are logs from Visual C++ compiler that should be never part of source control."

https://stackoverflow.com/a/51152764/429082
"They're output by MSBuild's File Tracker, which wraps Visual C++ build executables (e.g. cl.exe and link.exe) to track which files it writes to and reads from. It records these file paths in the .tlog files in an intermediate directory, and relies on these to define how an incremental build should be constructed."
If the exes aren't committed to source control, these shouldn't be either. Incremental build stuff is to speed up development iteration, and shouldn't be in source control.
